### PR TITLE
Allow Click to select current item

### DIFF
--- a/WheelPicker/src/main/java/com/aigestudio/wheelpicker/IWheelPicker.java
+++ b/WheelPicker/src/main/java/com/aigestudio/wheelpicker/IWheelPicker.java
@@ -46,6 +46,16 @@ public interface IWheelPicker {
     void setVisibleItemCount(int count);
 
     /**
+     *
+     * <p>
+     * 设置是否可以点击小部件（滑动小于 touchSlop）
+     * 如果是，则使用当前选择的项目触发OnItemSelected事件
+     *
+     * @param allowClick 允许用户单击以选择当前突出显示的项目
+     */
+    void setAllowClick(boolean allowClick);
+
+    /**
      * 滚轮选择器数据项是否为循环状态
      * <p>
      * Whether WheelPicker is cyclic or not

--- a/WheelPicker/src/main/java/com/aigestudio/wheelpicker/WheelPicker.java
+++ b/WheelPicker/src/main/java/com/aigestudio/wheelpicker/WheelPicker.java
@@ -270,6 +270,11 @@ public class WheelPicker extends View implements IDebug, IWheelPicker, Runnable 
     private boolean isClick;
 
     /**
+     * 是否允许点击触发事件
+     */
+    private boolean mAllowClick;
+
+    /**
      * 是否为强制结束滑动
      */
     private boolean isForceFinishScroll;
@@ -710,7 +715,14 @@ public class WheelPicker extends View implements IDebug, IWheelPicker, Runnable 
             case MotionEvent.ACTION_UP:
                 if (null != getParent())
                     getParent().requestDisallowInterceptTouchEvent(false);
-                if (isClick) break;
+                if (isClick) {
+                    if(mAllowClick) {
+                        if (null != mOnItemSelectedListener) {
+                            int position = (-mScrollOffsetY / mItemHeight + mSelectedItemPosition) % mData.size();
+                            mOnItemSelectedListener.onItemSelected(this, mData.get(position), position);
+                        }
+                    }
+                }
                 mTracker.addMovement(event);
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.DONUT)
@@ -806,6 +818,11 @@ public class WheelPicker extends View implements IDebug, IWheelPicker, Runnable 
         mVisibleItemCount = count;
         updateVisibleItemCount();
         requestLayout();
+    }
+
+    @Override
+    public void setAllowClick(boolean allowClick) {
+        mAllowClick = allowClick;
     }
 
     @Override

--- a/WheelPicker/src/main/java/com/aigestudio/wheelpicker/widgets/WheelDatePicker.java
+++ b/WheelPicker/src/main/java/com/aigestudio/wheelpicker/widgets/WheelDatePicker.java
@@ -33,6 +33,7 @@ public class WheelDatePicker extends LinearLayout implements WheelPicker.OnItemS
     private TextView mTVYear, mTVMonth, mTVDay;
 
     private int mYear, mMonth, mDay;
+    private boolean mAllowClick;
 
     public WheelDatePicker(Context context) {
         this(context, null);
@@ -111,6 +112,11 @@ public class WheelDatePicker extends LinearLayout implements WheelPicker.OnItemS
         mPickerYear.setVisibleItemCount(count);
         mPickerMonth.setVisibleItemCount(count);
         mPickerDay.setVisibleItemCount(count);
+    }
+
+    @Override
+    public void setAllowClick(boolean allowClick) {
+        mAllowClick = allowClick;
     }
 
     @Override


### PR DESCRIPTION
Replaced the break after isClick in the movement checker, which, according to an allowClick flag, triggers onItemSelected after a user clicks the widget. Also added to the interface for other widgets to use.

I also fixed it in the demo application so that it could compile (due to the change to IWheelPicker), but you may want to reorganize that at your discretion. 