### PR TITLE
Update WheelPicker.java

### DIFF
--- a/WheelPicker/src/main/java/com/aigestudio/wheelpicker/WheelPicker.java
+++ b/WheelPicker/src/main/java/com/aigestudio/wheelpicker/WheelPicker.java
@@ -710,7 +710,7 @@ public class WheelPicker extends View implements IDebug, IWheelPicker, Runnable 
             case MotionEvent.ACTION_UP:
                 if (null != getParent())
                     getParent().requestDisallowInterceptTouchEvent(false);
-                if (isClick) break;
+                if (isClick && !isForceFinishScroll) break;
                 mTracker.addMovement(event);
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.DONUT)


### PR DESCRIPTION
when wheelPicker is scrolling， a click is on and scrolling is abandoned, so wheelPicker may stop at not a selected position where mScrollOffsetY % mItemHeight is not zero.