### PR TITLE
Allow Spannable to be used instead of Strings

### DIFF
--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.2"
 
     defaultConfig {
         applicationId "com.aigestudio.wheelpicker.demo"
-        minSdkVersion 1
-        targetSdkVersion 24
+        minSdkVersion 16
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -20,5 +20,5 @@ android {
 }
 
 dependencies {
-    compile project(':WheelPicker')
+    implementation project(':WheelPicker')
 }

--- a/WheelPicker/build.gradle
+++ b/WheelPicker/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 android {
-    compileSdkVersion 24
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.2"
 
     defaultConfig {
-        minSdkVersion 1
-        targetSdkVersion 24
+        minSdkVersion 16
+        targetSdkVersion 28
         versionCode 7
         versionName "1.1.2"
     }
@@ -19,5 +19,5 @@ android {
     sourceSets { main { assets.srcDirs = ['src/main/assets', 'src/main/assets/'] } }
 }
 dependencies {
-    compile 'com.google.code.gson:gson:2.2.4'
+    implementation 'com.google.code.gson:gson:2.8.2'
 }

--- a/WheelPicker/src/main/java/com/aigestudio/wheelpicker/IWheelPicker.java
+++ b/WheelPicker/src/main/java/com/aigestudio/wheelpicker/IWheelPicker.java
@@ -219,7 +219,7 @@ public interface IWheelPicker {
      *
      * @return 最宽的文本
      */
-    String getMaximumWidthText();
+    CharSequence getMaximumWidthText();
 
     /**
      * 设置最宽的文本
@@ -229,7 +229,7 @@ public interface IWheelPicker {
      * @param text 最宽的文本
      * @see #setSameWidth(boolean)
      */
-    void setMaximumWidthText(String text);
+    void setMaximumWidthText(CharSequence text);
 
     /**
      * 获取最宽的文本在数据源中的位置

--- a/WheelPicker/src/main/java/com/aigestudio/wheelpicker/WheelPicker.java
+++ b/WheelPicker/src/main/java/com/aigestudio/wheelpicker/WheelPicker.java
@@ -767,12 +767,15 @@ public class WheelPicker extends View implements IDebug, IWheelPicker, Runnable 
                     mScroller.abortAnimation();
                     isForceFinishScroll = true;
                 }
-                mDownPointY = mLastPointY = (int) event.getY();
+                mDownPointY = mLastPointY = Math.round(event.getY());
                 break;
             case MotionEvent.ACTION_MOVE:
-                if (Math.abs(mDownPointY - event.getY()) < mTouchSlop) {
+                if (mDownPointY == mLastPointY && Math.abs(mDownPointY - event.getY()) < mTouchSlop) {
                     isClick = true;
                     break;
+                }
+                if (isClick) {
+                    mLastPointY = Math.round(event.getY());
                 }
                 isClick = false;
                 mTracker.addMovement(event);
@@ -784,7 +787,7 @@ public class WheelPicker extends View implements IDebug, IWheelPicker, Runnable 
                 float move = event.getY() - mLastPointY;
                 if (Math.abs(move) < 1) break;
                 mScrollOffsetY += move;
-                mLastPointY = (int) event.getY();
+                mLastPointY = Math.round(event.getY());
                 invalidate();
                 break;
             case MotionEvent.ACTION_UP:

--- a/WheelPicker/src/main/java/com/aigestudio/wheelpicker/widgets/WheelDatePicker.java
+++ b/WheelPicker/src/main/java/com/aigestudio/wheelpicker/widgets/WheelDatePicker.java
@@ -196,7 +196,7 @@ public class WheelDatePicker extends LinearLayout implements WheelPicker.OnItemS
 
     @Deprecated
     @Override
-    public void setMaximumWidthText(String text) {
+    public void setMaximumWidthText(CharSequence text) {
         throw new UnsupportedOperationException("You don't need to set maximum width text for" +
                 "WheelDatePicker");
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,17 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:3.1.4'
     }
 }
 
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip


### PR DESCRIPTION
This allows `Spannable` text to be used in the WheelPicker.  It keeps the existing `String.valueOf()` logic in place for other object types but if it is a `Spannable` it will use a `TextPaint` based on the spans contained in the text.