### PR TITLE
Fix setSelectedItemPosition(animated) malfunction when invoked early

### DIFF
--- a/Demo/src/main/java/com/aigestudio/wheelpicker/demo/PreviewActivity.java
+++ b/Demo/src/main/java/com/aigestudio/wheelpicker/demo/PreviewActivity.java
@@ -29,6 +29,7 @@ public class PreviewActivity extends Activity implements WheelPicker.OnItemSelec
         wheelLeft = (WheelPicker) findViewById(R.id.main_wheel_left);
         wheelLeft.setOnItemSelectedListener(this);
         wheelCenter = (WheelPicker) findViewById(R.id.main_wheel_center);
+        wheelCenter.setSelectedItemPosition(2);
         wheelCenter.setOnItemSelectedListener(this);
         wheelRight = (WheelPicker) findViewById(R.id.main_wheel_right);
         wheelRight.setOnItemSelectedListener(this);

--- a/WheelPicker/src/main/java/com/aigestudio/wheelpicker/WheelPicker.java
+++ b/WheelPicker/src/main/java/com/aigestudio/wheelpicker/WheelPicker.java
@@ -854,7 +854,8 @@ public class WheelPicker extends View implements IDebug, IWheelPicker, Runnable 
 
     public void setSelectedItemPosition(int position, final boolean animated) {
       isTouchTriggered = false;
-      if (animated && mScroller.isFinished()) { // We go non-animated regardless of "animated" parameter if scroller is in motion
+      boolean isComponentDrawn = mItemHeight > 0;
+      if (animated && isComponentDrawn && mScroller.isFinished()) { // We go non-animated regardless of "animated" parameter if scroller is in motion, or component is not drawn yet
         int length = getData().size();
         int itemDifference = position - mCurrentItemPosition;
         if (itemDifference == 0)


### PR DESCRIPTION
Fix malfunction of `setSelectedItemPosition` method when invoked with `animated=true` (which is the default condition) before the component is drawn and `itemHeight` is calculated.