### PR TITLE
Added functionality to set font from font resources

### DIFF
--- a/WheelPicker/build.gradle
+++ b/WheelPicker/build.gradle
@@ -28,4 +28,5 @@ publish {
 dependencies {
     implementation 'com.google.code.gson:gson:2.8.2'
     implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:support-v4:28.0.0'
 }

--- a/WheelPicker/build.gradle
+++ b/WheelPicker/build.gradle
@@ -27,4 +27,5 @@ publish {
 }
 dependencies {
     implementation 'com.google.code.gson:gson:2.8.2'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
 }

--- a/WheelPicker/src/main/java/com/aigestudio/wheelpicker/WheelPicker.java
+++ b/WheelPicker/src/main/java/com/aigestudio/wheelpicker/WheelPicker.java
@@ -11,6 +11,7 @@ import android.graphics.Region;
 import android.graphics.Typeface;
 import android.os.Build;
 import android.os.Handler;
+import android.support.v4.content.res.ResourcesCompat;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -20,7 +21,6 @@ import android.view.View;
 import android.view.ViewConfiguration;
 import android.widget.Scroller;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -322,6 +322,7 @@ public class WheelPicker extends View implements IDebug, IWheelPicker, Runnable 
         isCurved = a.getBoolean(R.styleable.WheelPicker_wheel_curved, false);
         mItemAlign = a.getInt(R.styleable.WheelPicker_wheel_item_align, ALIGN_CENTER);
         fontPath = a.getString(R.styleable.WheelPicker_wheel_font_path);
+        int fontFamily = a.getResourceId(R.styleable.WheelPicker_wheel_font_family, 0);
         a.recycle();
 
         // 可见数据项改变后更新与之相关的参数
@@ -334,6 +335,15 @@ public class WheelPicker extends View implements IDebug, IWheelPicker, Runnable 
         if (fontPath != null) {
             Typeface typeface = Typeface.createFromAsset(context.getAssets(), fontPath);
             setTypeface(typeface);
+        }
+
+        if (fontFamily != 0) {
+            try {
+                Typeface typeface = ResourcesCompat.getFont(context, fontFamily);
+                setTypeface(typeface);
+            } catch (Exception e) {
+                Log.e("Error setting typeface", e.getMessage(), e);
+            }
         }
 
         // 更新文本对齐方式

--- a/WheelPicker/src/main/res/values/attrs.xml
+++ b/WheelPicker/src/main/res/values/attrs.xml
@@ -25,5 +25,6 @@
             <enum name="right" value="2" />
         </attr>
         <attr name="wheel_font_path" format="string" />
+        <attr name="wheel_font_family" format="reference" />
     </declare-styleable>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ allprojects {
         jcenter()
         google()
         mavenCentral()
+        maven { url 'https://maven.google.com/' }
     }
 }
 task clean(type: Delete) {


### PR DESCRIPTION
Font resource can be set through `app:wheel_font_family` attribute.

**Example:** If you have a `my_font` family in your `font` resource directory, then you'll set:
```XML
<com.aigestudio.wheelpicker.WheelPicker
    ...
    app:wheel_font_family="@font/my_font"
    ... />
```



**Note:** font set from font resources will override fonts set from assets folder with `app:wheel_font_path`.